### PR TITLE
OP-2177: fixing issues with Searcher in Grievances View

### DIFF
--- a/src/components/TicketFilter.js
+++ b/src/components/TicketFilter.js
@@ -83,7 +83,7 @@ class TicketFilter extends Component {
                   {
                     id: 'code',
                     value: v,
-                    filter: `code_Istartswith: "${v}"`,
+                    filter: `code_Icontains: "${v}"`,
                   },
                 ])}
               />
@@ -104,7 +104,7 @@ class TicketFilter extends Component {
                   {
                     id: 'title',
                     value: v,
-                    filter: `title_Istartswith: "${v}"`,
+                    filter: `title_Icontains: "${v}"`,
                   },
                 ])}
               />
@@ -159,6 +159,7 @@ class TicketFilter extends Component {
                 pubRef="grievanceSocialProtection.TicketStatusPicker"
                 label="ticket.ticketStatus"
                 value={this._filterValue('status')}
+                withNull
                 onChange={(v) => this.debouncedOnChangeFilter([
                   {
                     id: 'status',

--- a/src/pickers/TicketStatusPicker.js
+++ b/src/pickers/TicketStatusPicker.js
@@ -9,6 +9,7 @@ class TicketStatusPicker extends Component {
   render() {
     const {
       readOnly = false,
+      withNull = false,
       value,
       onChange,
     } = this.props;
@@ -16,11 +17,11 @@ class TicketStatusPicker extends Component {
     return (
       <ConstantBasedPicker
         module="grievance"
-        label="Ticket Status"
+        label="ticket.ticketStatus"
         constants={TICKET_STATUS}
         readOnly={readOnly}
         value={value}
-        withNull={false}
+        withNull={withNull}
         onChange={(option) => onChange(option, option ? `${option}` : null)}
         {...this.props}
       />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -76,7 +76,7 @@
     "Ticket Status.IN_PROGRESS":"In Progress",
     "Ticket Status.RESOLVED":"Resolved",
     "ticketStatus.CLOSED":"Closed",
-    "ticket.ticketStatus.null":"None",
+    "ticket.ticketStatus.null":"Any",
     "ticket.ticketStatus.RECEIVED":"Received",
     "ticket.ticketStatus.OPEN":"Open",
     "ticket.ticketStatus.IN_PROGRESS":"In Progress",


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2177

- Fixed "search by title only match string% and I was expecting to match %string%"
![Screenshot from 2024-11-20 14-09-43](https://github.com/user-attachments/assets/fd9d87bd-cfb3-49a5-b5fe-8b30eb30adf7)

- Fixed "status option None should be renamed to Any as it matches any status". 
![Screenshot from 2024-11-20 14-09-55](https://github.com/user-attachments/assets/fdac25a0-cd89-4ea6-83f4-d4cac54cce76)

Note: 'In the results list, I was expecting to see the Reporter as the user who created the ticket. None is displayed:' -> here in reporter if user is not selected - it should be 'Anonymous User'. See second screenshot. Moreover you can see that if Individual act as Reporter - Individual picker is visible as 'Reporter'