### PR TITLE
OP-2220: improved displaying beneficiary data when beneficiary is selected

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -38,6 +38,7 @@ export function fetchTicketSummaries(mm, filters) {
     'priority', 'dueDate', 'reporter', 'reporterId',
     'reporterType', 'reporterTypeName', 'category', 'flags',
     'channel', 'resolution', 'title', 'dateOfIncident', 'dateCreated', 'version', 'isHistory',
+    'reporterFirstName', 'reporterLastName', 'reporterDob',
   ];
   const payload = formatPageQueryWithCount(
     'tickets',
@@ -54,6 +55,7 @@ export function fetchTicket(mm, filters) {
     'reporterType', 'reporterTypeName', 'category', 'flags', 'channel',
     'resolution', 'title', 'dateOfIncident', 'dateCreated',
     'attendingStaff {id, username}', 'version', 'isHistory,', 'jsonExt',
+    'reporterFirstName', 'reporterLastName', 'reporterDob',
   ];
   const payload = formatPageQueryWithCount(
     'tickets',
@@ -78,6 +80,9 @@ export function fetchComments(ticket) {
       'comment',
       'isResolution',
       'dateCreated',
+      'commenterFirstName',
+      'commenterLastName',
+      'commenterDob',
     ];
     const payload = formatPageQueryWithCount(
       'comments',
@@ -129,7 +134,7 @@ export function formatUpdateTicketGQL(ticket) {
       ? `reporterId: "${decodeId(ticket.reporter.id)}"`
       : `reporterId: "${ticket.reporter.id}"`)
     : ''}
-    ${!!ticket.reporter && !!ticket.reporter ? 'reporterType: "Individual"' : ''}
+    ${!!ticket.reporter && !!ticket.reporter ? `reporterType: "${ticket.reporterTypeName}"` : ''}
     ${ticket.nameOfComplainant ? `nameOfComplainant: "${formatGQLString(ticket.nameOfComplainant)}"` : ''}
     ${ticket.resolution ? `resolution: "${formatGQLString(ticket.resolution)}"` : ''}
     ${ticket.status ? `status: ${formatGQLString(ticket.status)}` : ''}

--- a/src/components/TicketCommentsPanel.js
+++ b/src/components/TicketCommentsPanel.js
@@ -230,6 +230,25 @@ class TicketCommentPanel extends Component {
             />
           );
         }
+        if (comment.commenterTypeName === 'beneficiary') {
+          picker = (
+            <PublishedComponent
+              pubRef="socialProtection.BeneficiaryPicker"
+              readOnly
+              value={
+                {
+                  individual: {
+                    firstName: comment.commenterFirstName,
+                    lastName: comment.commenterLastName,
+                    dob: comment.commenterDob,
+                  },
+                }
+              }
+              module={MODULE_NAME}
+              label={formatMessage(this.props.intl, MODULE_NAME, 'ticket.commenter')}
+            />
+          );
+        }
         if (comment.commenterTypeName === null) {
           picker = 'Anonymous User';
         }

--- a/src/components/TicketSearcher.js
+++ b/src/components/TicketSearcher.js
@@ -166,9 +166,13 @@ class TicketSearcher extends Component {
               label="ticket.reporter"
               required
               value={
-                reporter !== undefined
-                && reporter !== null ? (isEmptyObject(reporter)
-                    ? null : reporter) : null
+                {
+                  individual: {
+                    firstName: ticket.reporterFirstName,
+                    lastName: ticket.reporterLastName,
+                    dob: ticket.reporterDob,
+                  },
+                }
               }
             />
           );

--- a/src/dialogs/GrievanceCommentDialog.js
+++ b/src/dialogs/GrievanceCommentDialog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Grid } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import Button from '@material-ui/core/Button';
@@ -35,6 +35,7 @@ function GrievanceCommentDialog({
 }) {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
+  const [benefitPlan, setBenefitPlan] = useState(null);
   return (
     <>
       <Button
@@ -106,6 +107,30 @@ function GrievanceCommentDialog({
                     benefitPlan={null}
                   />
                 </Grid>
+              )}
+              {commenterType === 'beneficiary' && (
+              <>
+                <Grid item xs={3} className={classes.item}>
+                  <PublishedComponent
+                    pubRef="socialProtection.BenefitPlanPicker"
+                    withNull
+                    label="socialProtection.benefitPlan"
+                    value={benefitPlan}
+                    onChange={(v) => setBenefitPlan(v)}
+                  />
+                </Grid>
+                {benefitPlan && (
+                <Grid item xs={3} className={classes.item}>
+                  <PublishedComponent
+                    pubRef="socialProtection.BeneficiaryPicker"
+                    value={comment.reporter}
+                    label="ticket.commenter"
+                    onChange={(v) => updateCommentAttribute('commenter', v)}
+                    benefitPlan={benefitPlan}
+                  />
+                </Grid>
+                )}
+              </>
               )}
               <Grid item xs={12} className={classes.item}>
                 <TextInput

--- a/src/pages/EditTicketPage.js
+++ b/src/pages/EditTicketPage.js
@@ -111,7 +111,6 @@ class EditTicketPage extends Component {
     const {
       stateEdited, reporter, comments,
     } = this.state;
-
     return (
       <div className={classes.page}>
         <Grid container>
@@ -183,29 +182,21 @@ class EditTicketPage extends Component {
                 </>
                 )}
                 {stateEdited.reporterTypeName === 'beneficiary' && (
-                <>
-                  <Grid item xs={4} className={classes.item}>
-                    <TextInput
-                      module={MODULE_NAME}
-                      label="ticket.nationalId"
-                      value={reporter?.jsonExt?.national_id ?? ''}
-                      required={false}
-                      readOnly
-                    />
-                  </Grid>
-                  <Grid item xs={4} className={classes.item}>
-                    <TextInput
-                      module={MODULE_NAME}
-                      label="ticket.email"
-                      value={!!stateEdited && !!stateEdited.reporter
-                        ? this.extractFieldFromJsonExt(reporter, 'email')
-                        : EMPTY_STRING}
-                      onChange={(v) => this.updateAttribute('email', v)}
-                      required={false}
-                      readOnly
-                    />
-                  </Grid>
-                </>
+                <PublishedComponent
+                  pubRef="socialProtection.BeneficiaryPicker"
+                  onChange={(v) => this.updateAttribute('reporter', v)}
+                  readOnly
+                  value={
+                    {
+                      individual: {
+                        firstName: stateEdited.reporterFirstName,
+                        lastName: stateEdited.reporterLastName,
+                        dob: stateEdited.reporterDob,
+                      },
+                    }
+                  }
+                  module={MODULE_NAME}
+                />
                 )}
               </Grid>
             </Paper>


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2220

Changes:
- now beneficiary pickers displays data related to individual basic data in ticket and comment 
- currently we know who is the beneficiary in comments
- changes related to backend changes - additional fields coming from backend in gql query (see https://github.com/openimis/openimis-be-grievance_social_protection_py/pull/30)

Changes proved by screenshots from local env:
![Screenshot from 2024-12-16 15-38-13](https://github.com/user-attachments/assets/98782698-1e8a-4d1f-9b49-1b32b24d6223)
![Screenshot from 2024-12-16 15-38-03](https://github.com/user-attachments/assets/9580dd1f-6fc7-4085-abf5-6b9acf0d3d34)
![Screenshot from 2024-12-16 15-37-55](https://github.com/user-attachments/assets/818999d4-d72e-4c5b-88ba-ef9731ef0531)
![Screenshot from 2024-12-16 15-37-44](https://github.com/user-attachments/assets/ba48b9a6-4f59-4c0c-b1f7-1e6655ccef84)
