### PR TITLE
fix: use correct action types for ticket comment mutations - OP-2844

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -266,7 +266,7 @@ export function createTicketComment(ticketComment, ticket, commenterType, client
   const requestedDateTime = new Date();
   return graphql(
     mutation.payload,
-    ['TICKET_ATTACHMENT_MUTATION_REQ', 'TICKET_CREATE_TICKET_ATTACHMENT_RESP', 'TICKET_ATTACHMENT_MUTATION_ERR'],
+    ['TICKET_COMMENT_MUTATION_REQ', 'TICKET_CREATE_COMMENT_RESP', 'TICKET_COMMENT_MUTATION_ERR'],
     {
       clientMutationId: mutation.clientMutationId,
       clientMutationLabel,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -259,6 +259,12 @@ function reducer(
       return dispatchMutationErr(state, action);
     case 'TICKET_CREATE_TICKET_ATTACHMENT_RESP':
       return dispatchMutationResp(state, 'createTicketAttachment', action);
+    case 'TICKET_COMMENT_MUTATION_REQ':
+      return dispatchMutationReq(state, action);
+    case 'TICKET_COMMENT_MUTATION_ERR':
+      return dispatchMutationErr(state, action);
+    case 'TICKET_CREATE_COMMENT_RESP':
+      return dispatchMutationResp(state, 'createComment', action);
     default:
       return state;
   }


### PR DESCRIPTION
## Summary

- `createTicketComment` in `actions.js` was incorrectly dispatching Redux actions using the *attachment* action type strings (`TICKET_ATTACHMENT_MUTATION_REQ/RESP/ERR`) instead of comment-specific ones — a copy-paste error from the attachment flow
- Because no reducer case matched those strings, the mutation response was silently dropped, leaving the UI in a broken state and triggering the fatal error dialog
- Added `TICKET_COMMENT_MUTATION_REQ`, `TICKET_COMMENT_MUTATION_ERR`, and `TICKET_CREATE_COMMENT_RESP` cases to `reducer.js` to correctly handle the comment mutation lifecycle

## Root Cause

Fatal Error Dialog from the attachment flow: the action type array passed to `graphql()` in `createTicketComment` referenced attachment constants instead of comment constants.

## Test plan

Detailed Tests for whole module are added in a separate [PR](https://github.com/openimis/openimis-dist_dkr/pull/84). This is to fix so that tests can pass.
